### PR TITLE
Fix venv + remove config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BUILD_DIR=build
 
 release: clean
 	mkdir $(BUILD_DIR)
-	zip -r $(BUILD_DIR)/jee-pee-tee.zip lambda -x lambda/.venv
+	zip -r $(BUILD_DIR)/jee-pee-tee.zip lambda -x lambda/\config.example.json -x lambda/\.venv/\*
 
 
 clean:


### PR DESCRIPTION
had wrong exclude structure for venv and was also including example config. 

```
(.venv) malachi@pulsar jee-pee-tee $ make
rm -rf build
mkdir build
zip -r build/jee-pee-tee.zip lambda -x lambda/\config.example.json -x lambda/\.venv/\*
  adding: lambda/ (stored 0%)
  adding: lambda/requirements.txt (stored 0%)
  adding: lambda/lambda_function.py (deflated 75%)
  adding: lambda/utils.py (deflated 56%)
```